### PR TITLE
Typographical error 3-1

### DIFF
--- a/kagome-vqe.ipynb
+++ b/kagome-vqe.ipynb
@@ -1154,7 +1154,7 @@
     "    # Prepare extended primitive\n",
     "    rt_estimator = RetryEstimator(session=session)\n",
     "    # set up algorithm\n",
-    "    custom_vqe = CustomVQE(rt_estimator, ansatz_opt, optimizer, callback=callback_real)\n",
+    "    custom_vqe = CustomVQE(rt_estimator, ansatz_opt, optimizer, callback=callback_sim)\n",
     "    # run algorithm\n",
     "    result = custom_vqe.compute_minimum_eigenvalue(ham_16)\n",
     "end = time.time()\n",


### PR DESCRIPTION
3-1 Qiskit runtime (cloud simulator)

I think it should be: callback=callback_sim 
rather than callback=callback_real